### PR TITLE
Remove Travis build status from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Apache Fineract CN Service Starter [![Build Status](https://api.travis-ci.com/apache/fineract-cn-service-starter.svg?branch=develop)](https://travis-ci.com/apache/fineract-cn-service-starter)
+# Apache Fineract CN Service Starter
 
 
 This project makes it possible to start services locally for the purpose of writing integration tests.


### PR DESCRIPTION
Due to the removal of the Travis build scripts from the project. The build status in the README.md is now misleading and needs to be removed.